### PR TITLE
Missing radix parameter - 10

### DIFF
--- a/booking/src/components/CreateBooking.js
+++ b/booking/src/components/CreateBooking.js
@@ -36,7 +36,7 @@ class CreateBooking extends Component {
     //Событие для работы с каледарем (Трекбаром)
     setCalendarEndDate(days){        
         let end = moment(this.state.startDate);
-        end.add(parseInt(days), "days");
+        end.add(parseInt(days, 10), "days");
         this.setState({
             endDate: end,
             days: days


### PR DESCRIPTION
If radix is undefined or 0, it is assumed to be 10 except when the number begins with the character pairs 0x or 0X, in which case a radix of 16 is assumed.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt#ECMAScript_5_removes_octal_interpretation